### PR TITLE
Fix the download links after graduation

### DIFF
--- a/download/index.mdx
+++ b/download/index.mdx
@@ -2,9 +2,9 @@
 title: Download
 ---
 
-## Apache Kvrocks(incubating) Downloads
+## Apache Kvrocks Downloads
 
-Apache Kvrocks(incubating) is released as a source artifact. We are pleased to announce our release as below.
+Apache Kvrocks is released as a source artifact. We are pleased to announce our release as below.
 
 ### Releases
 
@@ -14,7 +14,7 @@ import Releases from "../src/components/Releases";
 <Releases/>
 ````
 
-Choose a source distribution in the *tar* format, and [verify](https://www.apache.org/dyn/closer.cgi#verify) using the corresponding *pgp* signature (using the committer file in [KEYS](https://downloads.apache.org/incubator/kvrocks/KEYS)).  If you cannot do that, the *sha512* hash file may be used to check that the download has completed OK.
+Choose a source distribution in the *tar* format, and [verify](https://www.apache.org/dyn/closer.cgi#verify) using the corresponding *pgp* signature (using the committer file in [KEYS](https://downloads.apache.org/kvrocks/KEYS)).  If you cannot do that, the *sha512* hash file may be used to check that the download has completed OK.
 
 For fast downloads, current source distributions are hosted on mirror servers; older source distributions are in the
-[archive](https://archive.apache.org/dist/incubator/kvrocks/). If a download from a mirror fails, retry, and the second download will likely succeed.
+[archive](https://archive.apache.org/dist/kvrocks/). If a download from a mirror fails, retry, and the second download will likely succeed.

--- a/src/components/Releases/index.tsx
+++ b/src/components/Releases/index.tsx
@@ -14,9 +14,13 @@ type ReleaseData = {
     signature: string,
 }
 
-function createReleaseData(version: string): ReleaseData {
-    const vtag = `${version}-incubating`
-    const archive = `https://downloads.apache.org/incubator/kvrocks/${version}/apache-kvrocks-${vtag}-src.tar.gz`
+function createReleaseData(index: number, version: string): ReleaseData {
+    var vtag = `${version}-incubating`
+    // Drop the incubating suffix for releases after graduation
+    if (index >= 4) {
+        vtag = `${version}`
+    }
+    const archive = `https://downloads.apache.org/kvrocks/${version}/apache-kvrocks-${vtag}-src.tar.gz`
     return {
         name: vtag,
         archive: archive,
@@ -26,7 +30,7 @@ function createReleaseData(version: string): ReleaseData {
 }
 
 export default function Releases(): JSX.Element {
-    const releases = versions.map(version => createReleaseData(version))
+    const releases = versions.map((version, index) => createReleaseData(versions.length-index-1, version))
     return <>
         <table>
             <thead>


### PR DESCRIPTION
As the title mentioned, we move the resource after graduation, so need to fix the old download links.

<img width="1214" alt="image" src="https://github.com/apache/kvrocks-website/assets/4987594/54195d8a-65b3-4631-98f4-f801f37e81b0">
