### PR TITLE
Update people link with project=kvrocks

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -78,7 +78,7 @@ Enhancements or new feature proposals are also welcome. The more concrete and ra
 
 ## People
 
-The list below could be outdated. Please find the most up-to-date list [here](https://people.apache.org/phonebook.html?podling=kvrocks).
+The list below could be outdated. Please find the most up-to-date list [here](https://people.apache.org/phonebook.html?project=kvrocks).
 
 ````mdx-code-block
 import Committers from "../src/components/Committers";


### PR DESCRIPTION
Currently using `podling=kvrocks` will show empty.