### PR TITLE
Remove the potentially misleading content in data-structure-on-rocksdb.md.

### DIFF
--- a/community/data-structure-on-rocksdb.md
+++ b/community/data-structure-on-rocksdb.md
@@ -104,11 +104,6 @@ We store the hash keys/values into a single key-value, assume we store millions 
 
 :::
 
-:::note What can we do if the user key is conflicted with the composed key?
-
-We store the metadata key and composed key in different column families, so it wouldn't happen.
-
-:::
 
 ## Set
 


### PR DESCRIPTION
This explanation is incorrect. The metadata key and sub key of the hash type are in the same column families.

I remove it to avoid misunderstandings.

