### PR TITLE
chore: use full form name when necessary

### DIFF
--- a/community/contributing.md
+++ b/community/contributing.md
@@ -3,14 +3,14 @@ id: contributing
 title: How to Contribute
 ---
 
-In order to build an active community to improve Kvrocks, we welcome and are eager to your contributions of all kinds, including but not limited to:
+In order to build an active community to improve Apache Kvrocks™, we welcome and are eager to your contributions of all kinds, including but not limited to:
 
 - suggesting new ideas or feature requests (please refer to the [Community](index.md) page);
 - reporting bugs and defects you find (please refer to the [Community](index.md) page);
 - contributing code changes (whether they are minor typo fixes, improvements, or major feature contributions);
 - fixing or improving the documentation or the project website.
 
-## Submit patches to Kvrocks
+## Submit patches
 
 ### Prerequisite
 

--- a/community/create-a-release.md
+++ b/community/create-a-release.md
@@ -1,6 +1,6 @@
 ---
 id: create-a-release
-title: Create a Kvrocks release
+title: Create a release
 ---
 
 This document mainly introduces how the Release Manager releases a new version in accordance with the Apache requirements.
@@ -8,7 +8,7 @@ This document mainly introduces how the Release Manager releases a new version i
 ## Introduction
 
 * Source Release is the key point which Apache values, also, is necessary for a release;
-* Binary Release is optional. Kvrocks can choose whether to release the binary package to the Apache repository or not.
+* Binary Release is optional. Apache Kvrocks™ can choose whether to release the binary package to the Apache repository or not.
 
 Note that for binary distribution packages, it is necessary to check that the new version does not contain third-party dependencies.
 

--- a/community/data-structure-on-rocksdb.md
+++ b/community/data-structure-on-rocksdb.md
@@ -1,6 +1,6 @@
-# Kvrocks data structures design
+# Data structures design
 
-Kvrocks uses the RocksDB as storage, it's developed by Facebook which is built on LevelDB with many extra features, like column family, transaction and backup, see the RocksDB wiki: [Features Not In LevelDB](https://github.com/facebook/RocksDB/wiki/Features-Not-in-LevelDB). The basic operations in RocksDB are `Put(key, value)`, `Get(key)`, `Delete(key)`, other complex structures aren't supported.
+Apache Kvrocks™ uses the RocksDB as storage, it's developed by Facebook which is built on LevelDB with many extra features, like column family, transaction and backup, see the RocksDB wiki: [Features Not In LevelDB](https://github.com/facebook/RocksDB/wiki/Features-Not-in-LevelDB). The basic operations in RocksDB are `Put(key, value)`, `Get(key)`, `Delete(key)`, other complex structures aren't supported.
 
 The main goal of this doc is to explain how we build the Redis hash/list/set/zset/bitmap/stream on RocksDB. Most of the design were derived from [Qihoo360/Blackwidow](https://github.com/Qihoo360/blackwidow), but with little modification, like the bitmap design, it's a fascinating part.
 

--- a/community/index.md
+++ b/community/index.md
@@ -42,7 +42,7 @@ If you email us with a code snippet, make sure that:
 
 ## Slack
 
-You can join the [Apache Kvrocks community on Slack](https://join.slack.com/t/kvrockscommunity/shared_invite/zt-p5928e3r-OUAK8SUgC8GOceGM6dAz6w).
+You can join the [Apache Kvrocks™ community on Slack](https://join.slack.com/t/kvrockscommunity/shared_invite/zt-p5928e3r-OUAK8SUgC8GOceGM6dAz6w).
 
 There are a couple of community rules:
 

--- a/community/vote-a-core-developer.md
+++ b/community/vote-a-core-developer.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 ````
 
-Kvrocks PMC member should be responsible for assessing the contributions of candidates.
+Apache Kvrocks™ PMC member should be responsible for assessing the contributions of candidates.
 
 Like many Apache projects, Kvrocks welcome all contributions, including code contributions, documentation improvement, blog entries, guides for new users, public speeches, and enhancement of the project in various ways.
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,5 +1,7 @@
 # Backup
 
+Apache Kvrocks™ supports full backup and incremental backup.
+
 ## Full backup
 
 You can use `bgsave` command to trigger Kvrocks to generate a backup, and use `rsync` tool to copy all files of backup to remote server.

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -1,6 +1,6 @@
 # Cluster
 
-Before releasing the cluster mode of Kvrocks, we usually used the pre-sharding way to scale out the capacity like sharding with Twemproxy, and used Redis Sentinel to guarantee the availability. Although it works well in most scenes since the capacity of Kvrocks is far larger than Redis, it’s still hard to scale-out in-flight, so we decided to implement the cluster mode to make it easier.
+Before releasing the cluster mode of Apache Kvrocks™, we usually used the pre-sharding way to scale out the capacity like sharding with Twemproxy, and used Redis Sentinel to guarantee the availability. Although it works well in most scenes since the capacity of Kvrocks is far larger than Redis, it’s still hard to scale-out in-flight, so we decided to implement the cluster mode to make it easier.
 
 There are two main types of Redis cluster solutions in the industry:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,8 @@
-# FAQs
+---
+sidebar_label: FAQs
+---
+
+# Apache Kvrocks™ FAQs
 
 **Question: How do I get keys num in Kvrocks?**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,6 +5,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 ````
 
+You can either get started with Apache Kvrocks™ with Docker or compile a binary from source.
+
 ## Run Kvrocks with Docker
 
 1. Follow Docker's [installation instructions](https://docs.docker.com/engine/installation/) to install Docker.

--- a/docs/info-sections.md
+++ b/docs/info-sections.md
@@ -1,6 +1,6 @@
 # INFO sections
 
-The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
+The INFO command returns information and statistics about the Apache Kvrocks™ server in a format that is simple to parse by computers and easy to read by humans.
 
 The optional section parameter can be used to select a specific section of information in form `INFO section section ...`:
 

--- a/docs/kvrocks-exporter.md
+++ b/docs/kvrocks-exporter.md
@@ -1,4 +1,8 @@
-# Kvrocks Exporter
+---
+sidebar_label: Metrics Exporter
+---
+
+# Exporter for Apache Kvrocks™
 
 Like the Redis metrics monitor, Kvrocks also exports the internal metrics to INFO commands.
 

--- a/docs/kvrocks2redis.md
+++ b/docs/kvrocks2redis.md
@@ -1,6 +1,6 @@
 ## kvrocks2redis
 
-kvrocks2redis is used to migrate the data from Kvrocks to Redis(as well as Kvrocks itself). It will read and parse data from the local dir first and then use the psync command to read the remain change streams from the target host.
+kvrocks2redis is used to migrate the data from Apache Kvrocks™ to Redis (as well as Kvrocks itself). It will read and parse data from the local dir first and then use the psync command to read the remain change streams from the target host.
 
 ## How to build
 

--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -1,6 +1,6 @@
 # Namespace
 
-Like the Redis database, Kvrocks uses the namespace to isolate the data between users. But unlike Redis, each namespace has its own password. The data would be stored in the default namespace when using `requirepass`. The namespace would have no effect when the cluster mode was enabled like the Redis DB.
+Like the Redis database, Apache Kvrocks™ uses the namespace to isolate the data between users. But unlike Redis, each namespace has its own password. The data would be stored in the default namespace when using `requirepass`. The namespace would have no effect when the cluster mode was enabled like the Redis DB.
 
 ## Manage Namespace
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,7 +6,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Apache Kvrocks',
+  title: 'Apache Kvrocks™',
   tagline: 'A distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol.',
   url: 'https://kvrocks.apache.org',
   baseUrl: '/',

--- a/download/index.mdx
+++ b/download/index.mdx
@@ -2,9 +2,9 @@
 title: Official Download
 ---
 
-## Apache Kvrocks Downloads
+## Apache Kvrocks™ Downloads
 
-Apache Kvrocks is released as a source artifact. We are pleased to announce our release as below.
+Apache Kvrocks™ is released as a source artifact. We are pleased to announce our release as below.
 
 ### Source Releases
 
@@ -21,7 +21,7 @@ For fast downloads, current source distributions are hosted on mirror servers; o
 
 ### Docker Images
 
-Every released version of Apache Kvrocks has a corresponding [official Docker image on Docker Hub](https://hub.docker.com/r/apache/kvrocks), which includes prebuilt binaries for both amd64 and arm64 architecture. You can obtain it via:
+Every released version of Apache Kvrocks™ has a corresponding [official Docker image on Docker Hub](https://hub.docker.com/r/apache/kvrocks), which includes prebuilt binaries for both amd64 and arm64 architecture. You can obtain it via:
 
 ```shell
 docker pull apache/kvrocks:$VERSION_NUMBER

--- a/download/third-party-packages.md
+++ b/download/third-party-packages.md
@@ -1,7 +1,7 @@
 # Third-party Packages
 
 In addition to [official releases](https://kvrocks.apache.org/download/), 
-there are some convenient packages for different Linux distros maintained outside the Kvrocks PMC.
+there are some convenient packages for different Linux distros maintained outside the Apache Kvrocks™ PMC.
 
 That said, these packages are **NOT** created or sponsored by the ASF.
 


### PR DESCRIPTION
According to https://www.apache.org/foundation/marks/guide:

> The first and most prominent mentions must use the full form: "Apache Hadoop®" of the name for any individual usage (webpage, handout, slides, etc.). Later in each specific document you may use the bare form of the name.