### PR TITLE
Add Dark Mode Support 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,7 +67,8 @@ const config = {
     ({
       colorMode: {
         defaultMode: 'light',
-        disableSwitch: true,
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
       },
       navbar: {
         title: 'Apache Kvrocks',

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -52,7 +52,7 @@ function Feature({imgPath,title, description}: FeatureItem) {
     <div className={clsx('col col--6')}>
       <div className="text--center padding-horiz--md" style={{width:"100%",height:"100%",margin:'30px 0px'}}>
         <img className={styles.imgItem} src={imgPath} alt={title}/>
-        <h3>{title}</h3>
+        <h3 className={styles.featureTitle}>{title}</h3>
         <div className={styles.itemDes}>
           <p>{description}</p>
         </div>

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -50,6 +50,10 @@
   color:rgba(59, 61, 63, 1)
 }
 
+[data-theme='dark'] .blueLine + p {
+  color:rgba(220, 220, 220, 1);
+}
+
 .redisCompatible{
   display:flex;
   flex-direction:row;
@@ -113,8 +117,20 @@
   color:rgba(59, 61, 63, 1);
 }
 
+[data-theme='dark'] .itemDes {
+  color:rgba(220, 220, 220, 1);
+}
+
 .itemDes p{
   width: 50%;
+}
+
+.featureTitle {
+  color: #333333;
+}
+
+[data-theme='dark'] .featureTitle {
+  color: #ffffff;
 }
 
 .container{

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,9 +7,34 @@
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #3071a9;
+  --ifm-color-primary-dark: #2b6698;
+  --ifm-color-primary-darker: #295f90;
+  --ifm-color-primary-darkest: #224e76;
+  --ifm-color-primary-light: #357cba;
+  --ifm-color-primary-lighter: #3782c2;
+  --ifm-color-primary-lightest: #4e93cd;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-  --ifm-footer-background-color:rgba(115, 150, 233, 0.61);
+  --ifm-footer-background-color: rgba(115, 150, 233, 0.61);
+  --ifm-background-color: #ffffff;
+  --ifm-navbar-background-color: #ffffff;
+}
+
+/* Dark mode overrides */
+[data-theme='dark'] {
+  --ifm-color-primary: #4e93cd;
+  --ifm-color-primary-dark: #3585c6;
+  --ifm-color-primary-darker: #2f7ebd;
+  --ifm-color-primary-darkest: #27689c;
+  --ifm-color-primary-light: #67a1d4;
+  --ifm-color-primary-lighter: #74a9d8;
+  --ifm-color-primary-lightest: #99c0e2;
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --ifm-background-color: #1e2125;
+  --ifm-navbar-background-color: #1e2125;
+  --ifm-footer-background-color: rgba(48, 56, 70, 0.8);
+  --ifm-heading-color: #ffffff;
+  --ifm-font-color-base: #e3e3e3;
 }
 
 .docusaurus-highlight-code-line {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -13,6 +13,10 @@
   flex-direction: column;
 }
 
+[data-theme='dark'] .heroBanner {
+  background-image:linear-gradient(to top, rgba(30, 40, 60, 1) , rgba(40, 50, 70, 1));
+}
+
 .container{
   width:100%;
   height:100%;
@@ -25,6 +29,15 @@
   width: 40%;
 }
 
+/* To make sure the hero title is seen in light mode, add certain styling */
+.titles h1 {
+  color: #333333;
+}
+
+[data-theme='dark'] .titles h1 {
+  color: #ffffff;
+}
+
 .image{
   width: 40%;
 }
@@ -34,6 +47,10 @@
   font-weight:light;
   margin-top:2rem;
   width:80%;
+}
+
+[data-theme='dark'] .tagline {
+  color:rgba(220, 220, 220, 1);
 }
 
 @media screen and (max-width: 950px) {
@@ -84,10 +101,24 @@
   border:1px solid rgba(0, 91, 244, 1);
 }
 
+[data-theme='dark'] .buttons a {
+  background-color:rgba(50, 60, 80, 1);
+  color:rgba(100, 160, 255, 1);
+  border:1px solid rgba(100, 160, 255, 1);
+  box-shadow:0pt 5pt 6pt 1pt rgba(0, 0, 0, 0.3);
+}
+
 .buttons a:first-child {
   background-color:rgba(40, 117, 243, 1);
   box-shadow:0pt 5pt 6pt 1pt rgba(0, 0, 0, 0.16);
   color:white
+}
+
+[data-theme='dark'] .buttons a:first-child {
+  background-color:rgba(60, 130, 240, 1);
+  box-shadow:0pt 5pt 6pt 1pt rgba(0, 0, 0, 0.3);
+  color:white;
+  border:1px solid rgba(60, 130, 240, 1);
 }
 
 @media screen and (max-width:820px){

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ function HomepageHeader() {
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className={clsx(styles.container)}>
           <div className={clsx(styles.titles)}>
-            <h1 className="hero__title" style={{color:'black'}}>{siteConfig.title}</h1>
+            <h1 className="hero__title">{siteConfig.title}</h1>
             <div className={clsx('hero__subtitle',styles.tagline)}>{siteConfig.tagline}</div>
           </div>
           <div className={clsx(styles.image)}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "module": "Node16",
+    "moduleResolution": "Node16"
   }
 }


### PR DESCRIPTION
This pull request contains several modifications to enhance the dark mode support and the visual coherence of the website. The most significant changes are to allow the color mode switch, updating dark mode styles, and introducing new CSS variables for color tuning.





Enhancements to dark mode support:

* [`docusaurus.config.js`](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL70-R71): Enabled the color mode switch and added support for respecting the user's preferred color scheme.
* [`src/css/custom.css`](diffhunk://#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570fR10-R37): Added dark mode overrides for primary colors, background colors, and other UI elements.

Updates to component styles:

* [`src/components/HomepageFeatures/index.tsx`](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877L55-R55): Updated the title element to use a new CSS class for consistent styling.
* [`src/components/HomepageFeatures/styles.module.css`](diffhunk://#diff-974d2f1dcc3826170a5f1aacfbbde839b4928a259eb7b664a4c161e70824b1dcR53-R56): Added dark mode styles for various elements, including descriptions and titles. [[1]](diffhunk://#diff-974d2f1dcc3826170a5f1aacfbbde839b4928a259eb7b664a4c161e70824b1dcR53-R56) [[2]](diffhunk://#diff-974d2f1dcc3826170a5f1aacfbbde839b4928a259eb7b664a4c161e70824b1dcR120-R135)

Improvements to homepage styles:

* [`src/pages/index.module.css`](diffhunk://#diff-d88ca19240bc4f47684fbd8108114ccbab409c5e48f93069f2e6567222b20b92R16-R19): Added dark mode styles for the hero banner, titles, taglines, and buttons to ensure readability and visual appeal. [[1]](diffhunk://#diff-d88ca19240bc4f47684fbd8108114ccbab409c5e48f93069f2e6567222b20b92R16-R19) [[2]](diffhunk://#diff-d88ca19240bc4f47684fbd8108114ccbab409c5e48f93069f2e6567222b20b92R32-R40) [[3]](diffhunk://#diff-d88ca19240bc4f47684fbd8108114ccbab409c5e48f93069f2e6567222b20b92R52-R55) [[4]](diffhunk://#diff-d88ca19240bc4f47684fbd8108114ccbab409c5e48f93069f2e6567222b20b92R104-R123)
* [`src/pages/index.tsx`](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987L15-R15): Removed inline styling for the hero title to use the new CSS classes for better maintainability.


https://github.com/user-attachments/assets/d840db7d-a241-4741-ab20-62f4e5b7ac5e




@PragmaTwice @git-hulk 