### PR TITLE
Add docs for TDIGEST.RESET

### DIFF
--- a/docs/supported-commands.md
+++ b/docs/supported-commands.md
@@ -442,3 +442,4 @@ In addition, `LISTFUNC` subcommand is added as an extension to list all function
 | TDIGEST.ADD         | ✓                | unstable      |                                                            |
 | TDIGEST.MIN         | ✓                | unstable      |                                                            |
 | TDIGEST.MAX         | ✓                | unstable      |                                                            |
+| TDIGEST.RESET       | ✓                | unstable      |                                                            |


### PR DESCRIPTION
Referencing: https://github.com/apache/kvrocks/pull/2826

This PR adds the ``TDIGEST.RESET`` command in the TDIGEST commands table under the Supported Commands section of the kvrocks [website](https://kvrocks.apache.org/docs/supported-commands#tdigest-commands).
