### PR TITLE
Add object command

### DIFF
--- a/docs/supported-commands.md
+++ b/docs/supported-commands.md
@@ -172,7 +172,7 @@ These commands are subcommands for `OBJECT`, using as `OBJECT DUMP` etc.
 
 | SUBCOMMAND | Supported OR Not | Since Version | Description                                                                                                   |
 | ---------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------- |
-| DUMP       | ✓                | v1.0.1        | Returns a serialized representation of the value stored at key.                                               |
+| DUMP       | ✓                | v1.0.1        | Dump the detailed information of the key.                                               |
 | ENCODING   | x                | -             | Returns the internal encoding of a object.                                                                    |
 | FREQ       | x                | -             | Returns the logarithmic access frequency counter of a object.                                                 |
 | IDLETIME   | x                | -             | Returns the time since the last access to a object.                                                           |

--- a/docs/supported-commands.md
+++ b/docs/supported-commands.md
@@ -154,6 +154,7 @@
 | PEXPIREAT   | ✓                | v1.0.0        | Sets a key's time to live based on a Unix timestamp in milliseconds. (Precision is in seconds if old encoding is used (see [#1033](https://github.com/apache/kvrocks/issues/1033))) |
 | PTTL        | ✓                | v1.0.0        | Returns the remaining time to live of a key in milliseconds. (precision is in seconds if old encoding is used (see [#1033](https://github.com/apache/kvrocks/issues/1033))) |
 | TTL         | ✓                | v1.0.0        | Returns the remaining time to live of a key in seconds.                                                      |
+| OBJECT         | ✓                | v1.0.1        | This is a container command for object introspection commands.                                                      |
 | TYPE        | ✓                | v1.0.0        | Returns the data type of the value stored at a key.                                                          |
 | SCAN        | ✓                | v1.0.0        | Incrementally iterates over keys in the keyspace.                                                            |
 | RENAME      | ✓                | v2.8.0        | Renames a key.                                                                                               |
@@ -164,6 +165,18 @@
 | MOVEX       | ✓                | v2.9.0        | Move a key between namespaces, see [#2225](https://github.com/apache/kvrocks/pull/2225)                      |
 | COPY        | ✓                | v2.9.0        | Copies a key to a new key.                                                                                   |
 | SORT        | ✓                | v2.9.0        | Sorts the elements in a list, set, or sorted set.                                                            |
+
+### OBJECT subcommands
+
+These commands are subcommands for `OBJECT`, using as `OBJECT DUMP` etc.
+
+| SUBCOMMAND | Supported OR Not | Since Version | Description                                                                                                   |
+| ---------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------- |
+| DUMP       | ✓                | v1.0.1        | Returns a serialized representation of the value stored at key.                                                          |
+| ENCODING       | x                | -        | Returns the internal encoding of a object.                                                          |
+| FREQ       | x                | -        | Returns the logarithmic access frequency counter of a object.                                                          |
+| IDLETIME       | x                | -        | Returns the time since the last access to a object.                                                          |
+| REFCOUNT       | x                | -        | Returns the reference count of a value of  key.                                                          |
 
 ## Bit commands
 

--- a/docs/supported-commands.md
+++ b/docs/supported-commands.md
@@ -154,7 +154,7 @@
 | PEXPIREAT   | ✓                | v1.0.0        | Sets a key's time to live based on a Unix timestamp in milliseconds. (Precision is in seconds if old encoding is used (see [#1033](https://github.com/apache/kvrocks/issues/1033))) |
 | PTTL        | ✓                | v1.0.0        | Returns the remaining time to live of a key in milliseconds. (precision is in seconds if old encoding is used (see [#1033](https://github.com/apache/kvrocks/issues/1033))) |
 | TTL         | ✓                | v1.0.0        | Returns the remaining time to live of a key in seconds.                                                      |
-| OBJECT         | ✓                | v1.0.1        | This is a container command for object introspection commands.                                                      |
+| OBJECT      | ✓                | v1.0.1        | This is a container command for object introspection commands.                                                     |
 | TYPE        | ✓                | v1.0.0        | Returns the data type of the value stored at a key.                                                          |
 | SCAN        | ✓                | v1.0.0        | Incrementally iterates over keys in the keyspace.                                                            |
 | RENAME      | ✓                | v2.8.0        | Renames a key.                                                                                               |
@@ -173,10 +173,10 @@ These commands are subcommands for `OBJECT`, using as `OBJECT DUMP` etc.
 | SUBCOMMAND | Supported OR Not | Since Version | Description                                                                                                   |
 | ---------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------- |
 | DUMP       | ✓                | v1.0.1        | Returns a serialized representation of the value stored at key.                                                          |
-| ENCODING       | x                | -        | Returns the internal encoding of a object.                                                          |
-| FREQ       | x                | -        | Returns the logarithmic access frequency counter of a object.                                                          |
-| IDLETIME       | x                | -        | Returns the time since the last access to a object.                                                          |
-| REFCOUNT       | x                | -        | Returns the reference count of a value of  key.                                                          |
+| ENCODING   | x                | -             | Returns the internal encoding of a object.                                                       |
+| FREQ       | x                | -             | Returns the logarithmic access frequency counter of a object.                                                       |
+| IDLETIME   | x                | -             | Returns the time since the last access to a object.                                                       |
+| REFCOUNT   | x                | -             | Returns the reference count of a value of  key.                                                          |
 
 ## Bit commands
 

--- a/docs/supported-commands.md
+++ b/docs/supported-commands.md
@@ -154,7 +154,7 @@
 | PEXPIREAT   | ✓                | v1.0.0        | Sets a key's time to live based on a Unix timestamp in milliseconds. (Precision is in seconds if old encoding is used (see [#1033](https://github.com/apache/kvrocks/issues/1033))) |
 | PTTL        | ✓                | v1.0.0        | Returns the remaining time to live of a key in milliseconds. (precision is in seconds if old encoding is used (see [#1033](https://github.com/apache/kvrocks/issues/1033))) |
 | TTL         | ✓                | v1.0.0        | Returns the remaining time to live of a key in seconds.                                                      |
-| OBJECT      | ✓                | v1.0.1        | This is a container command for object introspection commands.                                                     |
+| OBJECT      | ✓                | v1.0.1        | This is a container command for object introspection commands.                                               |
 | TYPE        | ✓                | v1.0.0        | Returns the data type of the value stored at a key.                                                          |
 | SCAN        | ✓                | v1.0.0        | Incrementally iterates over keys in the keyspace.                                                            |
 | RENAME      | ✓                | v2.8.0        | Renames a key.                                                                                               |
@@ -172,11 +172,11 @@ These commands are subcommands for `OBJECT`, using as `OBJECT DUMP` etc.
 
 | SUBCOMMAND | Supported OR Not | Since Version | Description                                                                                                   |
 | ---------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------- |
-| DUMP       | ✓                | v1.0.1        | Returns a serialized representation of the value stored at key.                                                          |
-| ENCODING   | x                | -             | Returns the internal encoding of a object.                                                       |
-| FREQ       | x                | -             | Returns the logarithmic access frequency counter of a object.                                                       |
-| IDLETIME   | x                | -             | Returns the time since the last access to a object.                                                       |
-| REFCOUNT   | x                | -             | Returns the reference count of a value of  key.                                                          |
+| DUMP       | ✓                | v1.0.1        | Returns a serialized representation of the value stored at key.                                               |
+| ENCODING   | x                | -             | Returns the internal encoding of a object.                                                                    |
+| FREQ       | x                | -             | Returns the logarithmic access frequency counter of a object.                                                 |
+| IDLETIME   | x                | -             | Returns the time since the last access to a object.                                                           |
+| REFCOUNT   | x                | -             | Returns the reference count of a value of  key.                                                               |
 
 ## Bit commands
 


### PR DESCRIPTION
this PR intents to resolve https://github.com/apache/kvrocks/issues/2587

Given the colossal list of subcommands, PRs are divided in redis groups.

references:
1. [OBJECT](https://redis.io/docs/latest/commands/?group=generic)