### PR TITLE
docs: add NixOS package

### DIFF
--- a/download/third-party-packages.md
+++ b/download/third-party-packages.md
@@ -21,6 +21,15 @@ is maintained by [@PragmaTwice](https://github.com/pragmatwice).
 Note that, like other AUR packages, the package does not contain binary files itself,
 since all binaries will be built by [makepkg](https://wiki.archlinux.org/title/makepkg) from the package scripts.
 
+### NixOS
+
+A [kvrocks](https://search.nixos.org/packages?query=kvrocks) package is maintained in
+[Nixpkgs](https://github.com/NixOS/nixpkgs). It can be tried in a temporary shell with
+`nix shell nixpkgs#kvrocks`, or installed declaratively on NixOS by adding `pkgs.kvrocks`
+to `environment.systemPackages`.
+
+You can check its package definition [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/kv/kvrocks/package.nix).
+
 ### Conda Forge
 
 A [kvrocks](https://anaconda.org/conda-forge/kvrocks) package is maintained in the [conda-forge](https://conda-forge.org/), which can be installed within one command like `conda install conda-forge::kvrocks`, via [conda](https://github.com/conda/conda) or [mamba](https://github.com/mamba-org/mamba).


### PR DESCRIPTION
## Summary

- document the Kvrocks package available through Nixpkgs
- add temporary-shell and declarative NixOS installation guidance
- link to the NixOS package search and package definition

## Validation

- Docusaurus production build
- NixOS package links return HTTP 200